### PR TITLE
Replace HttpBin with Postman-Echo

### DIFF
--- a/example/test.lua
+++ b/example/test.lua
@@ -32,7 +32,7 @@ local function test_download_json()
 end
 
 local function test_head()
-	local code, response = https.request("https://httpbin.org/get", {method = "HEAD"})
+	local code, response = https.request("https://postman-echo.com/get", {method = "HEAD"})
 	assert(code == 200, "expected code 200, got "..code)
 	assert(#response == 0, "expected empty response")
 end
@@ -40,7 +40,7 @@ end
 local function test_custom_header()
 	local headerName = "RandomNumber"
 	local random = math.random(1, 1000)
-	local code, response = https.request("https://httpbin.org/get", {
+	local code, response = https.request("https://postman-echo.com/get", {
 		headers = {
 			[headerName] = tostring(random)
 		}
@@ -71,7 +71,7 @@ local function test_send(method, kind)
 		contentType = "application/x-www-form-urlencoded"
 	end
 
-	local code, response = https.request("https://httpbin.org/"..method:lower(), {
+	local code, response = https.request("https://postman-echo.com/"..method:lower(), {
 		headers = {["Content-Type"] = contentType},
 		data = input(data),
 		method = method


### PR DESCRIPTION
Addresses [this issue](https://github.com/love2d/lua-https/issues/24) on the main repository. Tested the `test.lua` file using LÖVE 12 (which has lua-https built in):

```
lua-https main*​​ 
❯ lovec example
test downloading json library
test custom header
test POST with data send as form
test POST with data send as json
test PUT with data send as form
test PUT with data send as json
test PATCH with data send as form
test PATCH with data send as json
test DELETE with data send as form
test DELETE with data send as json
Test successful!
```